### PR TITLE
Fix navigation view autolayout warning

### DIFF
--- a/Shared/View/Menu/MenuView.swift
+++ b/Shared/View/Menu/MenuView.swift
@@ -42,6 +42,7 @@ struct MenuView: View {
             .listStyle(InsetListStyle())
             .navigationTitle("Featured")
         }
+        .navigationViewStyle(.stack)
         .task {
             await productStore.fetchProducts()
             await shoppingCartStore.fetchShoppingCart()


### PR DESCRIPTION
## What is in this PR

- Adds `navigationViewStyle` modifier 

## What does this do?

- Explicitly tell the navigation view how to lay itself out

## Resource

https://developer.apple.com/documentation/swiftui/text/navigationviewstyle(_:)