### PR TITLE
Auto save shopping cart on server 

### DIFF
--- a/Shared/Resources/ShoppingCart/ShoppingCart.swift
+++ b/Shared/Resources/ShoppingCart/ShoppingCart.swift
@@ -20,6 +20,10 @@ extension ShoppingCart {
         }
     }
 
+    var isEmpty: Bool {
+        orders.isEmpty
+    }
+    
     mutating func remove(at offsets: IndexSet) {
         orders.remove(atOffsets: offsets)
     }

--- a/Shared/Resources/ShoppingCart/ShoppingCart.swift
+++ b/Shared/Resources/ShoppingCart/ShoppingCart.swift
@@ -24,11 +24,16 @@ extension ShoppingCart {
         orders.isEmpty
     }
     
+    /// Only one order left in the shopping cart
+    var onlyOneLeft: Bool {
+        orders.count == 1
+    }
+    
     mutating func remove(at offsets: IndexSet) {
         orders.remove(atOffsets: offsets)
     }
 
-    // Add order to shopping cart based on different condition
+    /// Add order to shopping cart based on different condition
     mutating func addOrder(_ newOrder: Order) {
         // If the product of the new order already exists in the orders,
         // then get the sum of quantity as the updated quantity of the order for this specific product

--- a/Shared/Resources/ShoppingCart/ShoppingCartStore.swift
+++ b/Shared/Resources/ShoppingCart/ShoppingCartStore.swift
@@ -33,16 +33,7 @@ class ShoppingCartStore: ObservableObject {
             print("delete shopping cart error: \(error)")
         }
     }
-
-    func updateShoppingCart() async {
-        do {
-            let shoppingCart = try await shoppingCartService.updateShoppingCart(self.shoppingCart)
-            self.shoppingCart = shoppingCart
-        } catch {
-            print("update shopping cart error: \(error)")
-        }
-    }
-
+    
     func submitShoppingCart() async {
         do {
             let shoppingCart = try await shoppingCartService.submitShoppingCart(self.shoppingCart)
@@ -51,8 +42,34 @@ class ShoppingCartStore: ObservableObject {
             print("submit shopping cart error: \(error)")
         }
     }
+
+    /// If `shoppingCart` is empty, it will save one on the server, otherwise, updated the `shoppingCart` on server.
+    func addOrder(_ newOrder: Order) async {
+        if shoppingCart.isEmpty {
+            shoppingCart.addOrder(newOrder)
+            await saveShoppingCart()
+        } else {
+            shoppingCart.addOrder(newOrder)
+            await updateShoppingCart()
+        }
+    }
     
-    func saveShoppingCart() async {
+    /// Update existing `shoppingCart` on the sever
+    func updateOrder(_ order: Order) async {
+        shoppingCart.updateOrder(order)
+        await updateShoppingCart()
+    }
+    
+    private func updateShoppingCart() async {
+        do {
+            let shoppingCart = try await shoppingCartService.updateShoppingCart(self.shoppingCart)
+            self.shoppingCart = shoppingCart
+        } catch {
+            print("update shopping cart error: \(error)")
+        }
+    }
+
+    private func saveShoppingCart() async {
         do {
             let shoppingCart = try await shoppingCartService.saveShoppingCart(self.shoppingCart)
             self.shoppingCart = shoppingCart

--- a/Shared/Resources/ShoppingCart/ShoppingCartStore.swift
+++ b/Shared/Resources/ShoppingCart/ShoppingCartStore.swift
@@ -24,7 +24,6 @@ class ShoppingCartStore: ObservableObject {
             print("fetch shopping cart error: \(error)")
         }
     }
-    
     func submitShoppingCart() async {
         do {
             let shoppingCart = try await shoppingCartService.submitShoppingCart(self.shoppingCart)

--- a/Shared/Resources/ShoppingCart/ShoppingCartStore.swift
+++ b/Shared/Resources/ShoppingCart/ShoppingCartStore.swift
@@ -24,15 +24,6 @@ class ShoppingCartStore: ObservableObject {
             print("fetch shopping cart error: \(error)")
         }
     }
-
-    func deleteShoppingCart() async {
-        do {
-            _ = try await shoppingCartService.deleteShoppingCart(self.shoppingCart)
-            self.shoppingCart = ShoppingCart()
-        } catch {
-            print("delete shopping cart error: \(error)")
-        }
-    }
     
     func submitShoppingCart() async {
         do {
@@ -60,6 +51,18 @@ class ShoppingCartStore: ObservableObject {
         await updateShoppingCart()
     }
     
+    /// Delete `shoppingCart` from server if deleting the last order, otherwise update it.
+    func deleteOrder(index: IndexSet) async {
+        if shoppingCart.onlyOneLeft {
+            await deleteShoppingCart()
+        } else {
+            shoppingCart.remove(at: index)
+            await updateShoppingCart()
+        }
+    }
+
+    // MARK: - Private methods
+
     private func updateShoppingCart() async {
         do {
             let shoppingCart = try await shoppingCartService.updateShoppingCart(self.shoppingCart)
@@ -75,6 +78,15 @@ class ShoppingCartStore: ObservableObject {
             self.shoppingCart = shoppingCart
         } catch {
             print("save shopping cart error: \(error)")
+        }
+    }
+    
+    private func deleteShoppingCart() async {
+        do {
+            _ = try await shoppingCartService.deleteShoppingCart(self.shoppingCart)
+            self.shoppingCart = ShoppingCart()
+        } catch {
+            print("delete shopping cart error: \(error)")
         }
     }
 }

--- a/Shared/Resources/ShoppingCart/ShoppingCartStore.swift
+++ b/Shared/Resources/ShoppingCart/ShoppingCartStore.swift
@@ -80,7 +80,7 @@ class ShoppingCartStore: ObservableObject {
             print("save shopping cart error: \(error)")
         }
     }
-    
+
     private func deleteShoppingCart() async {
         do {
             _ = try await shoppingCartService.deleteShoppingCart(self.shoppingCart)

--- a/Shared/View/ProductDetails/ProductDetailsView.swift
+++ b/Shared/View/ProductDetails/ProductDetailsView.swift
@@ -55,10 +55,11 @@ struct ProductDetailsView: View {
                     }
 
                 Button(action: {
-                    // Trigger alert
                     isAdded = true
                     let order = Order(from: product, quantity: total)
-                    shoppingCartStore.shoppingCart.addOrder(order)
+                    Task {
+                        await shoppingCartStore.addOrder(order)
+                    }
                 }) {
                     Text(LocalizedStringKey("Add to Cart"))
                         .fontWeight(.semibold)

--- a/Shared/View/ShoppingCartView/EditShoppingCartView.swift
+++ b/Shared/View/ShoppingCartView/EditShoppingCartView.swift
@@ -56,10 +56,11 @@ struct EditShoppingCartView: View {
                     }
 
                 Button(action: {
-                    // Trigger alert once value is true
                     if quantityChanged {
                         isSaved = true
-                        updateShoppingCart()
+                        Task {
+                            await shoppingCartStore.updateOrder(order)
+                        }
                     }
                 }) {
                     Text(LocalizedStringKey("Save"))
@@ -79,17 +80,6 @@ struct EditShoppingCartView: View {
                                  dismissButton: button)
                 }
             }
-        }
-    }
-}
-
-extension EditShoppingCartView {
-    func updateShoppingCart() {
-        // TODO: Mabye we need to make the following call `await` as well? I am not sure.
-        shoppingCartStore.shoppingCart.updateOrder(order)
-        
-        Task {
-            await shoppingCartStore.updateShoppingCart()
         }
     }
 }

--- a/Shared/View/ShoppingCartView/ShoppingCartView.swift
+++ b/Shared/View/ShoppingCartView/ShoppingCartView.swift
@@ -52,18 +52,6 @@ struct ShoppingCartView: View {
                         }
                         .buttonStyle(DefaultButtonStyle())
                         .padding(.bottom)
-                        
-                        Button(action: {
-                            saveShoppingCart()
-                        }) {
-                            Text(LocalizedStringKey("Save order"))
-                                .fontWeight(.semibold)
-                                .font(.title3)
-                                .frame(width: 250, height: 50, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
-                        }
-                        .buttonStyle(DefaultButtonStyle())
-                        .padding(.bottom)
-                        
                     }
                 }
 
@@ -91,12 +79,6 @@ struct ShoppingCartView: View {
     private func submitShoppingCart() {
         Task {
             await shoppingCartStore.submitShoppingCart()
-        }
-    }
-    
-    private func saveShoppingCart() {
-        Task {
-            await shoppingCartStore.saveShoppingCart()
         }
     }
 }

--- a/Shared/View/ShoppingCartView/ShoppingCartView.swift
+++ b/Shared/View/ShoppingCartView/ShoppingCartView.swift
@@ -65,14 +65,8 @@ struct ShoppingCartView: View {
 
     /// Delete order from `shoppingCart`
     private func deleteOrder(index: IndexSet) {
-        var shoppingCart = shoppingCartStore.shoppingCart
-        let isLastOrderInCart = shoppingCart.orders.count == 1
-        if isLastOrderInCart {
-            Task {
-                await shoppingCartStore.deleteShoppingCart()
-            }
-        } else {
-            shoppingCart.remove(at: index)
+        Task {
+            await shoppingCartStore.deleteOrder(index: index)
         }
     }
     


### PR DESCRIPTION
## What is in this PR
* abstracted `addOrder` , `updateOrder` and `deleteOrder` in the `ShoppingCartStore`, view will not not modify `shoppingCart` directly. 

* When the user **Add** an `order`. App will save `shoppingCart` on server if it's empty, otherwise will update the `shoppingCart`. 

* When the user **Delete** an `order`. App will delete the entire `shoppingCart` if it has only one order left. Otherwise, update the shopping cart 